### PR TITLE
remove openssl from reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rtcm-rs = "0.11"
 futures = "0.3"
 tokio = { version = "1.48", features = ["full"] }
 strum = { version = "0.27.2", features = ["derive"] }
-reqwest = { version = "0.12", features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 http = "1.3"
 tokio-rustls = "0.26"
 rustls = "0.23.31"


### PR DESCRIPTION
`rustls` is much less gnarly to build for `musl` targets